### PR TITLE
expose some group metadata in REST API

### DIFF
--- a/inc/restapi.php
+++ b/inc/restapi.php
@@ -1,0 +1,40 @@
+<?php
+
+/**
+ * Make some custom post metadata available via the REST API
+ * Initially just for group status
+ */
+
+add_action('rest_api_init', 'u3a_setup_rest_meta_data');
+
+/**
+ * Make some group metadata readable via REST API
+ * To make other metadata fields available add further register_rest_field calls.
+ *
+ * @return void
+ */
+function u3a_setup_rest_meta_data()
+{
+    register_rest_field(
+        array(U3A_GROUP_CPT),
+        'groupstatus',
+        array(
+            'get_callback'    => 'get_post_meta_groupstatus',
+            'schema'          => null,
+        )
+    );
+}
+
+/**
+ * Make u3a group metadata field status_NUM available as 'groupstatus'
+ *
+ * @param WP $object
+ * @return (int) group status code
+ */
+function get_post_meta_groupstatus($object)
+{
+    $post_id = $object['id'];
+    $status = get_post_meta($post_id, 'status_NUM', true);
+    // error_log("Post ID $post_id " . $object['title']['rendered'] . " Status $status");
+    return (int) $status;
+}

--- a/u3a-siteworks-core.php
+++ b/u3a-siteworks-core.php
@@ -57,3 +57,6 @@ require_once "classes/class-u3a-common.php";
 U3aCommon::initialise(__FILE__);
 //require_once "classes/class-u3a-notice.php";
 U3aNotice::initialise(__FILE__);
+
+// Expose some metadata in REST API
+require_once "inc/restapi.php";


### PR DESCRIPTION
This code allows access to the metadata status_NUM value of a group via the REST API.  This is a stepping stone to being able to create an "Oversights" service that can remotely retrieve group names and status from individual SIteWorks sites.
I'd like to roll this out to production sites ASAP.