### PR TITLE
Nt 1004 add metafield render

### DIFF
--- a/classes/class-u3a-event.php
+++ b/classes/class-u3a-event.php
@@ -103,8 +103,8 @@ class U3aEvent
         // Customise the Quick Edit panel
         add_action('admin_head-edit.php', array(self::class, 'modify_quick_edit'));
 
-        // Convert event date to system format when rendered by the third party Meta Field Block
-        add_filter('meta_field_block_get_block_content', array(self::class, 'modify_meta_date'), 10, 2);
+        // Convert metadata fields to displayable text when rendered by the third party Meta Field Block
+        add_filter('meta_field_block_get_block_content', array(self::class, 'modify_meta_data'), 10, 2);
     
     }
 
@@ -577,14 +577,28 @@ class U3aEvent
     }
 
     /** 
-     * Convert event date to system format when rendered by the third party Meta Field Block.
+     * Convert event metadata to displayable text when rendered by the third party Meta Field Block.
+     * Ref https://wordpress.org/plugins/display-a-meta-field-as-block/
      * (WP won't have a problem if the block isn't present)
+     * Where metadata is stored as references/codes return the associated text string
+     * Where metadata is already in text form leave alone. 
      * @usedby filter 'meta_field_block_get_block_content'
      */
-    public static function modify_meta_date($content, $attributes)
+    public static function modify_meta_data($content, $attributes)
     {
-        if (($attributes['fieldName'] == 'eventDate') && ($content != '')) {
-            return date(get_option('date_format'), strtotime($content));
+        if ($content != '') {
+            switch ($attributes['fieldName']) {
+                case 'eventDate':
+                    $content = date(get_option('date_format'), strtotime($content));
+                    break;
+                case 'eventVenue_ID':
+                case 'eventGroup_ID':
+                case 'eventOrganiser_ID':
+                    $content = get_the_title($content);
+                    break;
+                case 'eventBookingRequired':
+                    $content = ($content == 0) ? 'No' : 'yes';
+            }
         }
         return $content;
     }

--- a/classes/class-u3a-event.php
+++ b/classes/class-u3a-event.php
@@ -597,7 +597,7 @@ class U3aEvent
                     $content = get_the_title($content);
                     break;
                 case 'eventBookingRequired':
-                    $content = ($content == 0) ? 'No' : 'yes';
+                    $content = ($content == 0) ? 'No' : 'Yes';
             }
         }
         return $content;

--- a/classes/class-u3a-group.php
+++ b/classes/class-u3a-group.php
@@ -123,6 +123,9 @@ class U3aGroup
         // Add action to restrict database field lengths
         add_action('save_post_u3a_group', [self::class, 'validate_group_fields'], 30, 2);
 
+        // Convert metadata fields to displayable text when rendered by the third party Meta Field Block
+        add_filter('meta_field_block_get_block_content', array(self::class, 'modify_meta_data'), 10, 2);
+
     }
 
     // validate the lengths of fields on save
@@ -1216,5 +1219,34 @@ class U3aGroup
             $html .= "</tr>";
         }
         return $html;
+    }
+
+    /** 
+     * Convert event metadata to displayable text when rendered by the third party Meta Field Block.
+     * Ref https://wordpress.org/plugins/display-a-meta-field-as-block/
+     * (WP won't have a problem if the block isn't present)
+     * Where metadata is stored as references/codes return the associated text string
+     * Where metadata is already in text form leave alone
+     * @usedby filter 'meta_field_block_get_block_content'
+     */
+    public static function modify_meta_data($content, $attributes)
+    {
+        if ($content != '' ) {
+            switch ($attributes['fieldName']) {
+                case 'status_NUM':
+                    $content = self::$status_list[$content];
+                    break;
+                case 'day_NUM':
+                    $content = ($content == 0) ? '' : self::$day_list[$content];
+                    break;
+                case 'venue_ID':
+                case 'coordinator_ID':
+                case 'coordinator2_ID':
+                case 'deputy_ID':
+                case 'tutor_ID':
+                    $content = get_the_title($content);
+            }
+        }
+        return $content;
     }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,7 @@ For more information please refer to the [SiteWorks website](https://siteworks.u
 Please refer to the documentation on the [SiteWorks website](https://siteworks.u3a.org.uk/u3a-siteworks-training/)
 
 == Changelog ==
+* Feature 1004: Add support for Meta Field Block to display all group and event metadata
 * Feature 991: Improve display of group contacts when 'hide email addresses' is off (Jan 2024)
 * Feature 994: Add editable attributes to event list and group list blocks (Jan 2024)
 = 1.0.5 =


### PR DESCRIPTION
Adds support to render all coded metadata as printable text when accessed from the Meta Field Block (plugin)