### PR TITLE
491 add REST API support for some Event CPT metadata

### DIFF
--- a/inc/restapi.php
+++ b/inc/restapi.php
@@ -1,8 +1,15 @@
 <?php
 
 /**
- * Make some custom post data available via the REST API
- * Initially just for group status and category
+ * Make some custom post data for Groups and Events available via the REST API
+ * Specifically for use with Oversights but may have other applications
+ * Provides fields:
+ *  - group status as 'groupstatus' (int)
+ *  - group category as 'groupcategory' (string)
+ *  - event category as 'eventcategory' (string)
+ *  - event date as 'eventdate' (string YYYY-MM-DD)
+ *  - event duration as 'eventduration' (int default 1)
+ *  - event groupname as 'eventgroup' (string default null for not a group event)
  */
 
 add_action('rest_api_init', 'u3a_setup_rest_meta_data');
@@ -31,7 +38,38 @@ function u3a_setup_rest_meta_data()
             'schema'          => null,
         )
     );
-    
+    register_rest_field(
+        array(U3A_EVENT_CPT),
+        'eventcategory',
+        array(
+            'get_callback'    => 'rest_get_u3a_eventcategory',
+            'schema'          => null,
+        )
+    );
+    register_rest_field(
+        array(U3A_EVENT_CPT),
+        'eventdate',
+        array(
+            'get_callback'    => 'rest_get_u3a_eventdate',
+            'schema'          => null,
+        )
+    );
+    register_rest_field(
+        array(U3A_EVENT_CPT),
+        'eventduration',
+        array(
+            'get_callback'    => 'rest_get_u3a_eventduration',
+            'schema'          => null,
+        )
+    );
+    register_rest_field(
+        array(U3A_EVENT_CPT),
+        'eventgroup',
+        array(
+            'get_callback'    => 'rest_get_u3a_eventgroup',
+            'schema'          => null,
+        )
+    );
 }
 
 /**
@@ -44,7 +82,6 @@ function rest_get_u3a_groupstatus($object)
 {
     $post_id = $object['id'];
     $status = get_post_meta($post_id, 'status_NUM', true);
-    // error_log("Post ID $post_id " . $object['title']['rendered'] . " Status $status");
     return (int) $status;
 }
 
@@ -59,6 +96,62 @@ function rest_get_u3a_groupcategory($object)
     $post_id = $object['id'];
     $cats = get_the_terms($post_id, U3A_GROUP_TAXONOMY);
     $cat = !empty($cats) ? $cats[0]->name : '';
-    // error_log("Post ID $post_id " . $object['title']['rendered'] . " Category $cat");
     return (string) $cat;
+}
+
+/**
+ * Make u3a event category available as 'eventcategory' (string)
+ *
+ * @param WP $object
+ * @return (string) event category text (first category only if more than one)
+ */
+function rest_get_u3a_eventcategory($object)
+{
+    $post_id = $object['id'];
+    $cats = get_the_terms($post_id, U3A_EVENT_TAXONOMY);
+    $cat = !empty($cats) ? $cats[0]->name : '';
+    return (string) $cat;
+}
+
+/**
+ * Make u3a event date available as 'eventdate' (string YYYY-MM-DD)
+ *
+ * @param WP $object
+ * @return (string) event date
+ */
+function rest_get_u3a_eventdate($object)
+{
+    $post_id = $object['id'];
+    $date = get_post_meta($post_id, 'eventDate', true);
+    return (string) $date;
+}
+
+/**
+ * Make u3a event duration in days available as 'eventduration' (int, default 1)
+ *
+ * @param WP $object
+ * @return (int) event duration in days
+ */
+function rest_get_u3a_eventduration($object)
+{
+    $post_id = $object['id'];
+    $days = get_post_meta($post_id, 'eventDays', true);
+    if (empty($days)) {
+        $days = 1;
+    }
+    return (int) $days;
+}
+
+/**
+ * Make group associated with u3a event available as 'eventgroup' (string, default null)
+ *
+ * @param WP $object
+ * @return (string) name of group associated with event or null string
+ */
+function rest_get_u3a_eventgroup($object)
+{
+    $post_id = $object['id'];
+    $groupID = get_post_meta($post_id, 'eventGroup_ID', true);
+    $groupName = empty($groupID) ? '' : get_the_title($groupID);
+    return (string) $groupName;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -22,7 +22,7 @@ Please refer to the documentation on the [SiteWorks website](https://siteworks.u
 == Changelog ==
 * Feature 1004: Add support for Meta Field Block to display all group and event metadata
 * Feature 1002: Choice of alphabetic flow in group list
-* Feature 491: Make group category available via REST API (Jan 2024)
+* Feature 491: Make some group and event metadata available via REST API (Feb 2024)
 * Feature 991: Improve display of group contacts when 'hide email addresses' is off (Jan 2024)
 * Feature 994: Add editable attributes to event list and group list blocks (Jan 2024)
 = 1.0.5 =


### PR DESCRIPTION
The same changes as made to Release-1.0.0 to add support for accessing some Event metadata via the REST API