### PR TITLE
1027 correct label for 'category' in u3a group list

### DIFF
--- a/classes/class-u3a-group.php
+++ b/classes/class-u3a-group.php
@@ -616,10 +616,11 @@ class U3aGroup
         }
         // set up some buttons to provide some built-in options
         $thispage = untrailingslashit(home_url($wp->request));
+        $category_singular_term = ucfirst(get_option('u3a_catsingular_term', 'category'));
         $html = <<<END
         <div class="u3agroupbuttons">
             <a class="wp-element-button" href="$thispage?sort=alpha">Alphabetical</a>
-            <a class="wp-element-button" href="$thispage?sort=cat">By Category</a>
+            <a class="wp-element-button" href="$thispage?sort=cat">By $category_singular_term</a>
             <a class="wp-element-button" href="$thispage?sort=day">By Meeting Day</a>
             <a class="wp-element-button" href="$thispage?sort=venue">By Venue</a>
         </div>

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === u3a-custom-post-types ===
 Requires at least: 5.9
-Tested up to: 6.4
+Tested up to: 6.5
 Stable tag: 5.9
 Requires PHP: 7.3
 License: GPLv2 or later
@@ -20,6 +20,8 @@ For more information please refer to the [SiteWorks website](https://siteworks.u
 Please refer to the documentation on the [SiteWorks website](https://siteworks.u3a.org.uk/u3a-siteworks-training/)
 
 == Changelog ==
+= 1.0.7 =
+* Bug 1027: Label for "category" in u3a group list does not respect u3a settings
 = 1.0.6 =
 * Feature 1004: Add support for Meta Field Block to display all group and event metadata (Feb 2024)
 * Feature 491: Make some group and event metadata available via REST API (Feb 2024)


### PR DESCRIPTION
Sorry - previous PR for this branch was against main, not release.  Hope I haven't broken anything!

The bug fix makes the text in the button in the u3a group list block respect the setting for the name to use for "category".
Ref https://project.u3awp.uk/projects/testing/work_packages/1027/activity

Similar change to go into main.
