### PR TITLE
1027 correct label for 'category' in u3a group list

### DIFF
--- a/classes/class-u3a-group.php
+++ b/classes/class-u3a-group.php
@@ -617,10 +617,11 @@ class U3aGroup
         }
         // set up some buttons to provide some built-in options
         $thispage = untrailingslashit(home_url($wp->request));
+        $category_singular_term = get_option('u3a_catsingular_term', 'category');
         $html = <<<END
         <div class="u3agroupbuttons">
             <a class="wp-element-button" href="$thispage?sort=alpha">Alphabetical</a>
-            <a class="wp-element-button" href="$thispage?sort=cat">By category</a>
+            <a class="wp-element-button" href="$thispage?sort=cat">By $category_singular_term</a>
             <a class="wp-element-button" href="$thispage?sort=day">By meeting day</a>
             <a class="wp-element-button" href="$thispage?sort=venue">By venue</a>
         </div>

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === u3a-custom-post-types ===
 Requires at least: 5.9
-Tested up to: 6.4
+Tested up to: 6.5
 Stable tag: 5.9
 Requires PHP: 7.3
 License: GPLv2 or later
@@ -20,6 +20,7 @@ For more information please refer to the [SiteWorks website](https://siteworks.u
 Please refer to the documentation on the [SiteWorks website](https://siteworks.u3a.org.uk/u3a-siteworks-training/)
 
 == Changelog ==
+* Bug 1027: Label for "category" in u3a group list does not respect u3a settings
 # Issues  #42 and #43 bug fixes
 * Feature 1004: Add support for Meta Field Block to display all group and event metadata
 * Feature 1002: Choice of alphabetic flow in group list


### PR DESCRIPTION
Similar change to the PR against the release branch.

This one generates lowercase text to match Mike's earlier changes to the other button text.