### PR TITLE
1024 - REST API returns multiple group categories

### DIFF
--- a/inc/restapi.php
+++ b/inc/restapi.php
@@ -5,7 +5,7 @@
  * Specifically for use with Oversights but may have other applications
  * Provides fields:
  *  - group status as 'groupstatus' (int)
- *  - group category as 'groupcategory' (string)
+ *  - group category as 'groupcategory' (string array)
  *  - event category as 'eventcategory' (string)
  *  - event date as 'eventdate' (string YYYY-MM-DD)
  *  - event duration as 'eventduration' (int default 1)
@@ -86,18 +86,27 @@ function rest_get_u3a_groupstatus($object)
 }
 
 /**
- * Make u3a group category available as 'groupcategory' (text)
+ * Make u3a group category available as 'groupcategory' (string array)
  *
  * @param WP $object
- * @return (string) group category text (first category only if more than one)
+ * 
+ * @return (array) group category text 
  */
 function rest_get_u3a_groupcategory($object)
 {
     $post_id = $object['id'];
     $cats = get_the_terms($post_id, U3A_GROUP_TAXONOMY);
-    $cat = !empty($cats) ? $cats[0]->name : '';
-    return (string) $cat;
+    if ($cats === false || is_wp_error($cats)) {
+        return array();
+    }
+    $cat_names = array();
+    foreach ($cats as $cat) {
+        $cat_names[] = $cat->name;
+    }
+    return $cat_names;
 }
+
+
 
 /**
  * Make u3a event category available as 'eventcategory' (string)

--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,7 @@ For more information please refer to the [SiteWorks website](https://siteworks.u
 Please refer to the documentation on the [SiteWorks website](https://siteworks.u3a.org.uk/u3a-siteworks-training/)
 
 == Changelog ==
+* Feature 1024: Support multiple u3a_group categories in REST API endpoint
 = 1.0.8 =
 * Bug 1027: Label for "category" in u3a group list does not respect u3a settings - further instances (March 2024)
 = 1.0.7 =


### PR DESCRIPTION
Change to the REST API endpoint to allow a string array of group categories to be returned instead of a single string.
Same change as to main.