### PR TITLE
1015 add optional event end time

### DIFF
--- a/inc/restapi.php
+++ b/inc/restapi.php
@@ -8,6 +8,8 @@
  *  - group category as 'groupcategory' (string array)
  *  - event category as 'eventcategory' (string)
  *  - event date as 'eventdate' (string YYYY-MM-DD)
+ *  - event start time as 'eventstarttime' (string HH:MM)
+ *  - event end time as 'eventendtime' (string HH:MM)
  *  - event duration as 'eventduration' (int default 1)
  *  - event groupname as 'eventgroup' (string default null for not a group event)
  */
@@ -55,6 +57,21 @@ function u3a_setup_rest_meta_data()
         )
     );
     register_rest_field(
+        array(U3A_EVENT_CPT),
+        'eventstarttime',
+        array(
+            'get_callback'    => 'rest_get_u3a_eventstarttime',
+            'schema'          => null,
+        )
+    );
+    register_rest_field(
+        array(U3A_EVENT_CPT),
+        'eventendtime',
+        array(
+            'get_callback'    => 'rest_get_u3a_eventendtime',
+            'schema'          => null,
+        )
+    );    register_rest_field(
         array(U3A_EVENT_CPT),
         'eventduration',
         array(
@@ -132,6 +149,33 @@ function rest_get_u3a_eventdate($object)
     $date = get_post_meta($post_id, 'eventDate', true);
     return (string) $date;
 }
+
+/**
+ * Make u3a event start time available as 'eventstarttime' (string HH:MM)
+ *
+ * @param WP $object
+ * @return (string) event date
+ */
+function rest_get_u3a_eventstarttime($object)
+{
+    $post_id = $object['id'];
+    $time = get_post_meta($post_id, 'eventTime', true);
+    return (string) $time;
+}
+
+/**
+ * Make u3a event start time available as 'eventendtime' (string HH:MM)
+ *
+ * @param WP $object
+ * @return (string) event date
+ */
+function rest_get_u3a_eventendtime($object)
+{
+    $post_id = $object['id'];
+    $time = get_post_meta($post_id, 'eventEndTime', true);
+    return (string) $time;
+}
+
 
 /**
  * Make u3a event duration in days available as 'eventduration' (int, default 1)

--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,7 @@ For more information please refer to the [SiteWorks website](https://siteworks.u
 Please refer to the documentation on the [SiteWorks website](https://siteworks.u3a.org.uk/u3a-siteworks-training/)
 
 == Changelog ==
+* Feature 1015: Add optional event end time (metadata field eventEndTime)
 * Feature 1024: Support multiple u3a_group categories in REST API endpoint
 * Bug 1027: Label for "category" in u3a group list does not respect u3a settings
 # Issues  #42 and #43 bug fixes


### PR DESCRIPTION
Feature approved by change board 15 March.
Adds option to provide and end time for an event.  New metadata field eventEndTime.
Also makes the event start and end times available via the REST API for Oversights or similar applications.