### PR TITLE
option to show venue in group lists

### DIFF
--- a/js/u3a-group-blocks.js
+++ b/js/u3a-group-blocks.js
@@ -35,10 +35,16 @@ wp.blocks.registerBlockType("u3a/grouplist", {
       },
       bwhen: {
         type: "boolean"
+      },
+      venue: {
+        type: "string"
+      },
+      bvenue: {
+        type: "boolean"
       }
     },
     edit: function( {attributes, setAttributes } ) {
-      const { cat, sort, flow, bstatus, status, bwhen, when } = attributes;
+      const { cat, sort, flow, bstatus, status, bwhen, when, bvenue, venue } = attributes;
       const onChangeCat = val => {
         setAttributes( { cat: val });
       };
@@ -59,6 +65,14 @@ wp.blocks.registerBlockType("u3a/grouplist", {
           setAttributes( { when: "y"});
         } else {
           setAttributes( { when: "n"});
+        }
+      };
+      const onChangeVenue = val => {
+        setAttributes( { bvenue: val});
+        if (val) {
+          setAttributes( { venue: "y"});
+        } else {
+          setAttributes( { venue: "n"});
         }
       };
       const onChangeFlow = val => {
@@ -160,6 +174,12 @@ wp.blocks.registerBlockType("u3a/grouplist", {
               { label:'Show Meeting Time', 
                 checked: bwhen,
                 onChange: onChangeWhen,
+              }
+            ),
+            wp.element.createElement( ToggleControl,
+              { label:'Show Venue',
+                checked: bvenue,
+                onChange: onChangeVenue,
               }
             )
           )

--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,7 @@ For more information please refer to the [SiteWorks website](https://siteworks.u
 Please refer to the documentation on the [SiteWorks website](https://siteworks.u3a.org.uk/u3a-siteworks-training/)
 
 == Changelog ==
+* Feature 1023: Option to display venue in group list.
 * Feature 1032: Alter group status text "Suspended" to "Dormant"
 * Feature 1015: Add optional event end time (metadata field eventEndTime)
 * Feature 1024: Support multiple u3a_group categories in REST API endpoint


### PR DESCRIPTION
This adds the venue to all except venue-sorted lists. The venue and its label are skipped if the venue is empty.
I have not altered the group list layout, but ideally the contents would be indented under the title, or at least the title could be bigger that the content.