### PR TITLE
default to all categories

### DIFF
--- a/js/u3a-group-blocks.js
+++ b/js/u3a-group-blocks.js
@@ -16,7 +16,8 @@ wp.blocks.registerBlockType("u3a/grouplist", {
     category: "widgets",
     attributes: {
       cat: {
-        type: "string"
+        type: "string",
+        default: "all"
       },
       sort: {
         type: "string"


### PR DESCRIPTION
Default to all categories so that the sort order is displayed when the properties are first opened.

Q: Is there a reason why we dont allow other sort orders then 'category' to be selected when within a single category?