### PR TITLE
1055 add support for Excerpt in Group and Venue CPTs

### DIFF
--- a/classes/class-u3a-group.php
+++ b/classes/class-u3a-group.php
@@ -173,7 +173,7 @@ class U3aGroup
         $args = array(
             'public' => true,
             'show_in_rest' => true,
-            'supports' => array('title', 'editor', 'author', 'thumbnail', 'color'),
+            'supports' => array('title', 'editor', 'author', 'thumbnail', 'excerpt', 'color'),
             'rewrite' => array('slug' => sanitize_title(U3A_GROUP_CPT . 's')),
             'has_archive' => false,
             'menu_icon' => U3A_GROUP_ICON,

--- a/classes/class-u3a-venue.php
+++ b/classes/class-u3a-venue.php
@@ -161,7 +161,7 @@ class U3aVenue
         $args = array(
             'public' => true,
             'show_in_rest' => true,
-            'supports' => array('title', 'editor', 'author', 'thumbnail'),
+            'supports' => array('title', 'editor', 'author', 'thumbnail', 'excerpt'),
             'rewrite' => array('slug' => sanitize_title(U3A_VENUE_CPT . 's')),
             'has_archive' => false,
             'menu_icon' => U3A_VENUE_ICON,

--- a/readme.txt
+++ b/readme.txt
@@ -20,6 +20,7 @@ For more information please refer to the [SiteWorks website](https://siteworks.u
 Please refer to the documentation on the [SiteWorks website](https://siteworks.u3a.org.uk/u3a-siteworks-training/)
 
 == Changelog ==
+* Bug 1055: add support for Excerpts when defining Group and Venue custom post types
 = 1.1.2 =
 * Bug 1048: venue not initialised in shortcode u3agrouplist
 * Bug 1046: u3a group list properties panel does not initially show Sort Order option

--- a/u3a-siteworks-core.php
+++ b/u3a-siteworks-core.php
@@ -2,7 +2,7 @@
 /*
 Plugin Name: u3a SiteWorks Core
 Description: Provides facility to manage content for u3a groups, events, notices and related contacts and venues.
-Version: 1.1.1
+Version: 1.1.2
 Author: u3a SiteWorks team
 Author URI: https://siteworks.u3a.org.uk/
 Plugin URI: https://siteworks.u3a.org.uk/
@@ -12,7 +12,7 @@ License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
 if (!defined('ABSPATH')) exit;
 
-define('U3A_SITEWORKS_CORE_VERSION', '1.1.1'); // Set to current plugin version number
+define('U3A_SITEWORKS_CORE_VERSION', '1.1.2'); // Set to current plugin version number
 
 // Check for metabox plugin present and activated
 if ((require_once "inc/check-metabox.php") == false) return;


### PR DESCRIPTION
Add 'excerpt' to the supports definition when creating Group and Venue CPTs
Also update version number in main plugin file to be consistent with the latest released version.