### PR TITLE
es_98

### DIFF
--- a/classes/class-u3a-event.php
+++ b/classes/class-u3a-event.php
@@ -663,7 +663,7 @@ class U3aEvent
      * @param array $atts Valid attributes are:
      *    when = 'past'/'future' (default future)
      *    order = 'asc'/'desc' (defaults to asc for future and desc for past)
-     *    cat = which event category to display (default all)
+     *    event_cat = which event category to display (default all)
      *    groups = 'y'/'n which will override the value in option settings
      *    limitnum (int) = limits how many events to be displayed
      *    limitdays (int) = limits how many day in the future or past to show events
@@ -680,7 +680,7 @@ class U3aEvent
             'showtitle' => 'y',
             'when' => 'future',
             'order' => '',
-            'cat' => 'all',
+            'event_cat' => 'all',
             'groups' => '',
             'limitdays' => 0,
             'limitnum' => 0,
@@ -716,7 +716,7 @@ class U3aEvent
             $order = ('future' == $when) ? 'ASC' : 'DESC';
         }
 
-        $cat = sanitize_text_field($display_args['cat']);
+        $cat = sanitize_text_field($display_args['event_cat']);
 
         $include_groups = $display_args['groups'];
         if ('y' != $include_groups && 'n' != $include_groups &&  '' != $include_groups) {
@@ -821,7 +821,7 @@ class U3aEvent
             $query_args['tax_query'] = [[
                 'taxonomy' => U3A_EVENT_TAXONOMY,
                 'field'    => 'slug',
-                'terms' => $cat, // could provide an aray of cats here!!
+                'terms' => $cat, // could provide an array of cats here!!
             ]];
         }
         $posts = get_posts($query_args);

--- a/classes/class-u3a-event.php
+++ b/classes/class-u3a-event.php
@@ -717,6 +717,10 @@ class U3aEvent
         }
 
         $cat = sanitize_text_field($display_args['event_cat']);
+        // backward compatibility
+        if ("" == $cat) {
+            $cat = sanitize_text_field($display_args['cat']);
+        }
 
         $include_groups = $display_args['groups'];
         if ('y' != $include_groups && 'n' != $include_groups &&  '' != $include_groups) {

--- a/classes/class-u3a-group.php
+++ b/classes/class-u3a-group.php
@@ -604,10 +604,10 @@ class U3aGroup
         global $wp;
         // valid display_args names and default values
         $display_args = [
-            'cat'  => 'all',
+            'group_cat'  => 'all',
             'sort' => 'alpha',
             'flow' => 'column',
-            'status' => 'y',
+            'group_status' => 'y',
             'when' => 'y',
             'venue' => 'n',
         ];
@@ -622,7 +622,7 @@ class U3aGroup
             }
         }
         $list_type = $display_args['sort'];
-        $cat = $display_args['cat'];
+        $cat = $display_args['group_cat'];
         $category_singular_term = get_option('u3a_catsingular_term', 'category');
         $html = '';
 
@@ -812,12 +812,12 @@ class U3aGroup
     {
         global $wp;
         // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-        $list_type = (isset($_GET['type'])) ? sanitize_text_field($_GET['type']) : "";
+        $list_type = (isset($_GET['list_type'])) ? sanitize_text_field($_GET['list_type']) : "";
         $get_group_listing = false;
         // valid display_args names and default values
         $display_args = [
             'flow' => 'column',
-            'status' => 'y',
+            'group_status' => 'y',
             'when' => 'n',
             'venue' => 'n',
         ];
@@ -859,7 +859,7 @@ class U3aGroup
 
             case 'day':
                 // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-                $day = (isset($_GET['day'])) ? sanitize_text_field($_GET['day']) : '';
+                $day = (isset($_GET['weekday'])) ? sanitize_text_field($_GET['weekday']) : '';
                 $none_msg = "<p>No groups found that meet on $day</p>";
                 if (!empty($day)) {
                     // $day_NUM = date("N", strtotime($day)) - 1;
@@ -951,7 +951,7 @@ class U3aGroup
      * @param array $posts all published group posts.
      *
      * @return HTML <div> with a set of links to current page with added query parameter,
-     *              specifying a letter, e,g ?type=letter&letter=b
+     *              specifying a letter, e,g ?list_type=letter&letter=b
      */
     public static function get_letter_list($posts)
     {
@@ -963,7 +963,7 @@ class U3aGroup
         $html = "<div class=\"u3agroupselector\">\n";
         foreach (range('A', 'Z') as $let) {
             if (strpos($letters_used, $let) === false) continue;
-            $url = untrailingslashit(home_url($wp->request)) . "?type=letter&letter=" . $let;
+            $url = untrailingslashit(home_url($wp->request)) . "?list_type=letter&letter=" . $let;
             $html .= "<a class='wp-element-button' href='" . $url . "' style='text-align: center; display:inline-block;'>" . $let . "</a>\n";
         }
         $html .= "</div>\n";
@@ -976,7 +976,7 @@ class U3aGroup
      * @param array $posts all published group posts.
      *
      * @return HTML <div> with a set of links to current page with added query parameter,
-     *              specifying a category, e,g ?type=par&par=Arts
+     *              specifying a category, e,g ?list_type=par&par=Arts
      */
     public static function get_parent_list($posts)
     {
@@ -992,7 +992,7 @@ class U3aGroup
         }
         $uniqueCats = array_unique($catsUsed);
         $html = "<div class=\"u3agroupselector\">\n";
-        $url = untrailingslashit(home_url($wp->request)) . "?type=par&par=";
+        $url = untrailingslashit(home_url($wp->request)) . "?list_type=par&par=";
         foreach ($uniqueCats as $catName) {
             $html .= "<a class='wp-element-button' href='" . $url . $catName . "' style='display:inline-block;'>" . $catName . "</a>";
         }
@@ -1007,7 +1007,7 @@ class U3aGroup
      * @param array $posts all published group posts.
      *
      * @return HTML <div> with a set of links to current page with added query parameter,
-     *              specifying a category, e,g ?type=day&day=Tuesday
+     *              specifying a category, e,g ?list_type=day&weekdayday=Tuesday
      */
     public static function get_day_list($posts)
     {
@@ -1019,7 +1019,7 @@ class U3aGroup
         }
         $uniqueDays = array_unique($daysUsed);
         asort($uniqueDays);
-        $url = untrailingslashit(home_url($wp->request)) . "?type=day&day=";
+        $url = untrailingslashit(home_url($wp->request)) . "?list_type=day&weekday=";
         $html = "<div class=\"u3agroupselector\">";
         foreach ($uniqueDays as $day_NUM) {
             $html .= "<a class='wp-element-button' style='display:inline-block;' href='" . $url . self::$day_list[$day_NUM] . "'>" . self::$day_list[$day_NUM] . "</a>";
@@ -1034,15 +1034,16 @@ class U3aGroup
      *
      * @param array $query_args parameters for WP_Query
      * @param array $display_args options for what info is displayed for each group
-     *        possble args:
-     *        'status' = y
+     *        possible args:
+     *        'group_status' = y
      *        'when' = y
+     *        'venue' = y
      * @param str $none_msg output if no matching groups found.
      * @return HTML <ul> with a list item for each group found.     
      */
     public static function display_selected_groups($query_args, $display_args, $none_msg = 'No groups.')
     {
-        $show_status = $display_args['status'];
+        $show_status = $display_args['group_status'];
         $show_when = $display_args['when'];
         $show_venue = $display_args['venue'];
 

--- a/classes/class-u3a-group.php
+++ b/classes/class-u3a-group.php
@@ -623,6 +623,10 @@ class U3aGroup
         }
         $list_type = $display_args['sort'];
         $cat = $display_args['group_cat'];
+        // backward compatibility
+        if ("" == $cat) {
+            $cat = $display_args['cat'];
+        }
         $category_singular_term = get_option('u3a_catsingular_term', 'category');
         $html = '';
 
@@ -1044,6 +1048,10 @@ class U3aGroup
     public static function display_selected_groups($query_args, $display_args, $none_msg = 'No groups.')
     {
         $show_status = $display_args['group_status'];
+        // backward compatibility
+        if ("" == $show_status) {
+            $show_status = $display_args['status'];
+        }
         $show_when = $display_args['when'];
         $show_venue = $display_args['venue'];
 

--- a/js/u3a-event-blocks.js
+++ b/js/u3a-event-blocks.js
@@ -28,7 +28,7 @@ wp.blocks.registerBlockType("u3a/eventdata", {
       order: {
         type: "string"
       },
-      cat: {
+      event_cat: {
         type: "string"
       },
       groups: {
@@ -55,7 +55,7 @@ wp.blocks.registerBlockType("u3a/eventdata", {
       },
     },
     edit: function( {attributes, setAttributes } ) {
-      const { when, order, cat, bgroups, groups, crop, limitnum, limitdays, layout, bgcolor, showtitle } = attributes;
+      const { when, order, event_cat, bgroups, groups, crop, limitnum, limitdays, layout, bgcolor, showtitle } = attributes;
       const onChangeShowTitle = val => {
         bshowtitle = val;
         if (val) {
@@ -71,8 +71,8 @@ wp.blocks.registerBlockType("u3a/eventdata", {
       const onChangeOrder = val => {
         setAttributes( { order: val });
       };
-      const onChangeCat = val => {
-        setAttributes( { cat: val})
+      const onChangeEventCat = val => {
+        setAttributes( { event_cat: val})
       };
       const onChangeGroups = val => {
         setAttributes( { bgroups: val})
@@ -198,9 +198,9 @@ wp.blocks.registerBlockType("u3a/eventdata", {
               ),
               wp.element.createElement( SelectControl,
                 { label:'Category', 
-                  value: cat,
+                  value: event_cat,
                   help: 'Either all categories or chosen category',
-                  onChange: onChangeCat,
+                  onChange: onChangeEventCat,
                   options: catlist
                 }
               )

--- a/js/u3a-group-blocks.js
+++ b/js/u3a-group-blocks.js
@@ -15,7 +15,7 @@ wp.blocks.registerBlockType("u3a/grouplist", {
     icon: "groups",
     category: "widgets",
     attributes: {
-      cat: {
+      group_cat: {
         type: "string",
         default: "all"
       },
@@ -25,7 +25,7 @@ wp.blocks.registerBlockType("u3a/grouplist", {
       flow: {
         type: "string"
       },
-      status: {
+      group_status: {
         type: "string"
       },
       bstatus: {
@@ -45,19 +45,19 @@ wp.blocks.registerBlockType("u3a/grouplist", {
       }
     },
     edit: function( {attributes, setAttributes } ) {
-      const { cat, sort, flow, bstatus, status, bwhen, when, bvenue, venue } = attributes;
-      const onChangeCat = val => {
-        setAttributes( { cat: val });
+      const { group_cat, sort, flow, bstatus, group_status, bwhen, when, bvenue, venue } = attributes;
+      const onChangeGroupCat = val => {
+        setAttributes( { group_cat: val });
       };
       const onChangeSort = val => {
         setAttributes( { sort: val });
       };
-      const onChangeStatus = val => {
+      const onChangeGroupStatus = val => {
         setAttributes( { bstatus: val });
         if (val) {
-          setAttributes( { status: "y"});
+          setAttributes( { group_status: "y"});
         } else {
-          setAttributes( { status: "n"});
+          setAttributes( { group_status: "n"});
         }
       };
       const onChangeWhen = val => {
@@ -127,14 +127,14 @@ wp.blocks.registerBlockType("u3a/grouplist", {
           {}, wp.element.createElement( PanelBody, {title:'Display options', initialOpen:true },
               wp.element.createElement( SelectControl,
                 { label:'Category', 
-                  value: cat,
+                  value: group_cat,
                   help: 'Either all categories or a single category',
-                  onChange: onChangeCat,
+                  onChange: onChangeGroupCat,
                   options: catlist
                 }
               ),
             wp.element.createElement(ShowOrNot,
-              { show:('all' == cat),
+              { show:('all' == group_cat),
                 el: wp.element.createElement( SelectControl,
                       { label:'Sort Order', 
                         value: sort,
@@ -168,7 +168,7 @@ wp.blocks.registerBlockType("u3a/grouplist", {
             wp.element.createElement( ToggleControl,
               { label:'Show Group Status', 
                 checked: bstatus,
-                onChange: onChangeStatus,
+                onChange: onChangeGroupStatus,
               }
             ),
             wp.element.createElement( ToggleControl,


### PR DESCRIPTION
I think this covers the required changes.

There are other cases which I have ignored:

1) 'status' is used as a $_GET query parameter in class_u3a_admin - I think thats a correct use of the reserved word.

'cat' is used as a value of a query parameter in some places - but thats fine, its the name of the parameter which cannot be a 
reserved word.

This change will have backward compatibility issues for anyone who has created these lists already, either as a shortcode or generated using the editor and attributes. This is because the display parameters as grabbed from either $atts or $_GET, but use the same parameter names, so I could not change the $_GET parameter names without changing the javascript which reads the 
attributes too.