### PR TITLE
workround for missing 'published'

### DIFF
--- a/inc/traits.php
+++ b/inc/traits.php
@@ -59,7 +59,7 @@ trait ModifyQuickEdit
             $(this).parent().parent().remove();
         });
         $('.inline-edit-date').each(function(i) {
-            $(this).remove();
+            $(this).hide();
         });
     });
 </script>


### PR DESCRIPTION
List of status shows 'published' and 'scheduled', but selects one based on the post date. If the date edit fields are removed, it assumes always 'scheduled'. Hiding the dates instead of removing them means it still finds the date, and can choose the correct option.