### PR TITLE
add back older versions of status and cat

### DIFF
--- a/classes/class-u3a-group.php
+++ b/classes/class-u3a-group.php
@@ -605,9 +605,11 @@ class U3aGroup
         // valid display_args names and default values
         $display_args = [
             'group_cat'  => 'all',
+            'cat' => 'all', // older version of group_cat
             'sort' => 'alpha',
             'flow' => 'column',
             'group_status' => 'y',
+            'status' => 'y', // older version of group_status
             'when' => 'y',
             'venue' => 'n',
         ];


### PR DESCRIPTION
I think adding these to the display_args will allow the old values to be found if the new ones are not set.