### PR TITLE
Backwards compatibility changes

### DIFF
--- a/classes/class-u3a-event.php
+++ b/classes/class-u3a-event.php
@@ -723,10 +723,6 @@ class U3aEvent
         }
 
         $cat = sanitize_text_field($display_args['event_cat']);
-        // backward compatibility
-        if ("" == $cat) {
-            $cat = sanitize_text_field($display_args['cat']);
-        }
 
         $include_groups = $display_args['groups'];
         if ('y' != $include_groups && 'n' != $include_groups &&  '' != $include_groups) {

--- a/classes/class-u3a-event.php
+++ b/classes/class-u3a-event.php
@@ -681,6 +681,7 @@ class U3aEvent
             'when' => 'future',
             'order' => '',
             'event_cat' => 'all',
+            'cat' => 'all', // deprecated version of event_cat kept for backward compatibility
             'groups' => '',
             'limitdays' => 0,
             'limitnum' => 0,
@@ -698,6 +699,11 @@ class U3aEvent
                 $display_args[$name] = strtolower($atts[$name]);
             }
         }
+        // For backwards compatibility, if $display_args['cat'] is set to a non-default value, use it!
+        if ($display_args['cat'] != 'all') {
+            $display_args['event_cat'] = $display_args['cat']
+        }
+
         // validate all args
         // do this by treating each arg explicitly
         $error = '';

--- a/classes/class-u3a-group.php
+++ b/classes/class-u3a-group.php
@@ -605,11 +605,11 @@ class U3aGroup
         // valid display_args names and default values
         $display_args = [
             'group_cat'  => 'all',
-            'cat' => 'all', // older version of group_cat
+            'cat' => 'all', // deprecated version of group_cat kept for backward compatibility
             'sort' => 'alpha',
             'flow' => 'column',
             'group_status' => 'y',
-            'status' => 'y', // older version of group_status
+            'status' => 'y', // deprecated version of group_status kept for backward compatibility
             'when' => 'y',
             'venue' => 'n',
         ];
@@ -623,12 +623,18 @@ class U3aGroup
                 $display_args[$name] = $atts[$name];
             }
         }
+        // For backwards compatibility, if $display_args['status'] is set to a non-default value, use it!
+        if ($display_args['status'] != 'y') {
+            $display_args['group_status'] = $display_args['status']
+        }
+        // For backwards compatibility, if $display_args['cat'] is set to a non-default value, use it!
+        if ($display_args['cat'] != 'all') {
+            $display_args['group_cat'] = $display_args['cat']
+        }
+
         $list_type = $display_args['sort'];
         $cat = $display_args['group_cat'];
-        // backward compatibility
-        if ("" == $cat) {
-            $cat = $display_args['cat'];
-        }
+
         $category_singular_term = get_option('u3a_catsingular_term', 'category');
         $html = '';
 
@@ -824,7 +830,8 @@ class U3aGroup
         $display_args = [
             'flow' => 'column',
             'group_status' => 'y',
-            'when' => 'n',
+            'status' => 'y', // deprecated version of group_status kept for backward compatibility
+            'when' => 'y',
             'venue' => 'n',
         ];
         // set from page query or from call attributes
@@ -837,7 +844,12 @@ class U3aGroup
                 $display_args[$name] = $atts[$name];
             }
         }
-        // Add back to list
+        // For backwards compatibility, if $display_args['status'] is set to a non-default value, use it!
+        if ($display_args['status'] != 'y') {
+            $display_args['group_status'] = $display_args['status']
+        }
+
+        // Add a link back to full group list
         $url = untrailingslashit(home_url($wp->request));
         $para_with_back_link = "<p><br><a class=\"wp-element-button\" href=\"$url\">Back to full group list</a></p>";
         $query_args = array(
@@ -1041,19 +1053,15 @@ class U3aGroup
      * @param array $query_args parameters for WP_Query
      * @param array $display_args options for what info is displayed for each group
      *        possible args:
-     *        'group_status' = y
-     *        'when' = y
-     *        'venue' = y
+     *        'group_status' = y/n
+     *        'when' = y/n
+     *        'venue' = y/n
      * @param str $none_msg output if no matching groups found.
      * @return HTML <ul> with a list item for each group found.     
      */
     public static function display_selected_groups($query_args, $display_args, $none_msg = 'No groups.')
     {
         $show_status = $display_args['group_status'];
-        // backward compatibility
-        if ("" == $show_status) {
-            $show_status = $display_args['status'];
-        }
         $show_when = $display_args['when'];
         $show_venue = $display_args['venue'];
 

--- a/classes/class-u3a-group.php
+++ b/classes/class-u3a-group.php
@@ -605,9 +605,11 @@ class U3aGroup
         // valid display_args names and default values
         $display_args = [
             'group_cat'  => 'all',
+            'cat' => 'all', // older version of group_cat
             'sort' => 'alpha',
             'flow' => 'column',
             'group_status' => 'y',
+            'status' => 'y', // older version of group_status
             'when' => 'y',
             'venue' => 'n',
         ];

--- a/js/u3a-group-blocks.js
+++ b/js/u3a-group-blocks.js
@@ -29,19 +29,22 @@ wp.blocks.registerBlockType("u3a/grouplist", {
         type: "string"
       },
       bstatus: {
-        type: "boolean"
+        type: "boolean",
+        default: true
       },
       when: {
         type: "string"
       },
       bwhen: {
-        type: "boolean"
+        type: "boolean",
+        default: true
       },
       venue: {
         type: "string"
       },
       bvenue: {
-        type: "boolean"
+        type: "boolean",
+        default: false
       }
     },
     edit: function( {attributes, setAttributes } ) {


### PR DESCRIPTION
If the old parameter (status or cat) has a non default value, we use it.
Otherwise we use the new parameter (group_status, group_cat of event_cat).
This works as if both old an new are their default values it is ok and if the new parameter is not default it must have been set deliberately.
All this code is executed immediately after the $display_args array has been set up.

I hope this is clear and correct!!
Mike