### PR TITLE
Enable Authors to edit their events, even if they do not own the group

### DIFF
--- a/classes/class-u3a-event.php
+++ b/classes/class-u3a-event.php
@@ -269,10 +269,51 @@ class U3aEvent
             'max'     => 100,
             'desc' => 'Optional',
         ];
-        if (!current_user_can('edit_others_posts')) {  // ie Editor or above
+        if (!current_user_can('edit_others_posts')) {  // ie Author or below
             $user = wp_get_current_user();
-            $group_post_query_args = ['author' => $user->ID, 'orderby' => 'title', 'order' => 'ASC'];
-        } else {
+			// We need to find the ids of all the groups that the user is allowed to edit the events of;
+            //   ie (1) all groups that the user is owner of, and (2) the groups of all events that the user is owner of
+
+			// (1) Find all the published groups the user is owner of
+			// (we assume that at this point there will be no relevant events for an unpublished group)
+			$query_args = [
+				'post_type' => U3A_GROUP_CPT,
+				'post_status' => 'publish',
+				'author' => $user->ID,
+			];
+			$groups_owned = get_posts($query_args);
+			// Get the ids of these groups
+			$groups_owned_ids = array_map( function($post) {
+				return $post->ID;
+			}, $groups_owned );
+
+            // (2) Find all the groups of all the events the user is owner of (regardless of the status of group or event)
+			$query_args = [
+				'post_type' => U3A_EVENT_CPT,
+				'post_status' => 'any',
+				'author' => $user->ID,
+			];
+			$events_owned = get_posts($query_args);
+			// Pick out the ids of the groups of those events
+			$events_owned_group_ids = [];
+			foreach ( $events_owned as $event ) {
+				$group_ID = $event->eventGroup_ID; // Note that since r21559 (v3.5) we no longer need to use get_post_meta
+			    if (!empty($group_ID)) $events_owned_group_ids[] = $group_ID;
+			}
+
+			// The final step is to get the union of the two arrays
+            //   this trick implements a Union of arrays of numbers
+			$all_allowed_group_ids = array_keys(
+				array_flip($groups_owned_ids) + array_flip($events_owned_group_ids)
+			);
+
+            // Because an empty array to post__in will return all posts we need to add an element to force it to return NO results
+            if (count($all_allowed_group_ids) === 0) {
+                $all_allowed_group_ids[] = 0;
+            }
+
+            $group_post_query_args = ['post__in' => $all_allowed_group_ids, 'orderby' => 'title', 'order' => 'ASC'];
+        } else {  // ie Editor or above
             $group_post_query_args = ['orderby' => 'title', 'order' => 'ASC'];
         }
         $fields[] = [


### PR DESCRIPTION
When authors create or edit an event, the event's group is a compulsory field. Currently, if an author owns an event but not its group (for whatever reason) then the Author can edit the event but not save their changes - because the group field is empty. This PR enables authors to edit such events.