### PR TITLE
Changes for 1.2.0 release

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === u3a-siteworks-core ===
 Requires at least: 5.9
-Tested up to: 6.7
+Tested up to: 6.8
 Stable tag: 5.9
 Requires PHP: 7.3
 License: GPLv2 or later
@@ -21,8 +21,15 @@ For guidance on the design of the code read file 'u3a Siteworks Core structure.o
 Please refer to the documentation on the [SiteWorks website](https://siteworks.u3a.org.uk/u3a-siteworks-training/)
 
 == Changelog ==
+= 1.2.0 =
+* Tested with WordPress 6.8
+* Feature 1130: Add option to hide list of events & groups on venue pages
+* Feature 1125: Events now sorted by time as well as date
 * Bug 1121: Duplicate entries in the reference lists for venues/contacts
 * Bug 1119: Provide validation of date format for u3a Notice start or end date
+* Feature 1105: Add new sorting and selection facilities to the 'u3a notice list' block
+* Bug 1103: Line breaks missing from search results
+* Code refactored to access plugin update service via configuration plugin
 = 1.1.6 =
 * Added documentation u3a Siteworks Core structure.odt
 * Refactored code for ease of future maintenance

--- a/u3a-siteworks-core.php
+++ b/u3a-siteworks-core.php
@@ -2,31 +2,38 @@
 /*
 Plugin Name: u3a SiteWorks Core
 Description: Provides facility to manage content for u3a groups, events, notices and related contacts and venues.
-Version: 1.1.6
+Version: 1.2.0
 Author: u3a SiteWorks team
 Author URI: https://siteworks.u3a.org.uk/
 Plugin URI: https://siteworks.u3a.org.uk/
 License: GPLv2
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
-Requires Plugins: meta-box
+Requires Plugins: meta-box, u3a-siteworks-configuration
 */
 
 if (!defined('ABSPATH')) exit;
 
-define('U3A_SITEWORKS_CORE_VERSION', '1.1.6'); // Set to current plugin version number
+define('U3A_SITEWORKS_CORE_VERSION', '1.2.0'); // Set to current plugin version number
 
 // Check for metabox plugin present and activated
 if ((require_once "inc/check-metabox.php") == false) return;
 
-// Use the plugin update service on SiteWorks update server
+// Use the plugin update service provided in the Configuration plugin
 
-require 'inc/plugin-update-checker/plugin-update-checker.php';
-use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
-
-$u3acptUpdateChecker = PucFactory::buildUpdateChecker(
-    'https://siteworks.u3a.org.uk/wp-update-server/?action=get_metadata&slug=u3a-siteworks-core', //Metadata URL
-    __FILE__, //Full path to the main plugin file or functions.php.
-    'u3a-siteworks-core'
+add_action(
+    'plugins_loaded',
+    function () {
+        if (function_exists('u3a_plugin_update_setup')) {
+            u3a_plugin_update_setup('u3a-siteworks-core', __FILE__);
+        } else {
+            add_action(
+                'admin_notices',
+                function () {
+                    print '<div class="error"><p>SiteWorks Core plugin unable to check for updates as the SiteWorks Configuration plugin is not active.</p></div>';
+                }
+            );
+        }
+    }
 );
 
 // Required files


### PR DESCRIPTION
Prepare for release 1.2.0.
Updated version numbers, readme.txt, switch update service code to use configuration plugin.
