### PR TITLE
author rights

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,7 @@ For guidance on the design of the code read file 'u3a Siteworks Core structure.o
 Please refer to the documentation on the [SiteWorks website](https://siteworks.u3a.org.uk/u3a-siteworks-training/)
 
 == Changelog ==
+* Revisit 1136 and 1126: Authors blocked from saving posts associated with group they do not own.
 = 1.2.1 =
 * Feature 1136: Allow authors to add non group events
 * Bug 1142: Notice block Title disappears when there are no notices


### PR DESCRIPTION
Prevent author from saving event if the author does not have rights to edit the associated group.
This will also prevent saving even if the author has selected a new group. The author will have to contact the group
editor or any administrator, and get the event disassociated from the group.