### PR TITLE
undo 1136

### DIFF
--- a/classes/class-u3a-event.php
+++ b/classes/class-u3a-event.php
@@ -269,7 +269,12 @@ class U3aEvent
             'max'     => 100,
             'desc' => 'Optional',
         ];
-        $group_post_query_args = ['orderby' => 'title', 'order' => 'ASC'];
+        if (!current_user_can('edit_others_posts')) {  // ie Editor or above
+            $user = wp_get_current_user();
+            $group_post_query_args = ['author' => $user->ID, 'orderby' => 'title', 'order' => 'ASC'];
+        } else {
+            $group_post_query_args = ['orderby' => 'title', 'order' => 'ASC'];
+        }
         $fields[] = [
             'type'       => 'post',
             'name'       => 'Group',
@@ -279,7 +284,7 @@ class U3aEvent
             'query_args' => $group_post_query_args,
             'field_type' => 'select_advanced', // this is the default anyway
             'ajax'       => false,  // this seems like a good choice, but try switching it on, when there a lots of groups??
-            'required' => false,  // 'Author' is allowed to save event without a group association
+            'required' => current_user_can('edit_others_posts') ? false : true,  // 'Author' must select a group
         ];
         $fields[] = [
             'type'       => 'post',

--- a/readme.txt
+++ b/readme.txt
@@ -21,6 +21,7 @@ For guidance on the design of the code read file 'u3a Siteworks Core structure.o
 Please refer to the documentation on the [SiteWorks website](https://siteworks.u3a.org.uk/u3a-siteworks-training/)
 
 == Changelog ==
+* Undo feature 1136
 = 1.2.1 =
 * Feature 1136: Allow authors to add non group events
 * Bug 1142: Notice block Title disappears when there are no notices


### PR DESCRIPTION
revert to authors being unable to save events if they do not own the group associated