### PR TITLE
fix backwards compatibility

### DIFF
--- a/classes/class-u3a-event.php
+++ b/classes/class-u3a-event.php
@@ -623,7 +623,7 @@ class U3aEvent
      *    when = 'past'/'future' (default future)
      *    order = 'asc'/'desc' (defaults to asc for future and desc for past)
      *    event_cat = which event category to display (default all)
-     *    groups = 'useglobal', 'exclude', 'include' which will override the value in option settings
+     *    groups = corresponds to 'show group events and is 'useglobal' or 'y' or 'n'
      *    limitnum (int) = limits how many events to be displayed
      *    limitdays (int) = limits how many day in the future or past to show events
      *    layout = 'list' or 'grid' at present. Other layouts may be added
@@ -678,19 +678,23 @@ class U3aEvent
 
         $cat = sanitize_text_field($display_args['event_cat']);
 
-        $include_groups = $display_args['groups'];
+        $groups = $display_args['groups'];
+
+
         if (
-            'useglobal' != $include_groups && 'exclude' != $include_groups
-            &&  'include' != $include_groups && '' != $include_groups
+            'useglobal' != $groups && 'y' != $groups
+            &&  'n' != $groups && '' != $groups
         ) {
-            $error .= 'bad parameter: groups=' . esc_html($include_groups) . '<br>';
-            $include_groups = '';
+            $error .= 'bad parameter: groups=' . esc_html($groups) . '<br>';
+            $groups = '';
         }
-        if ('' == $include_groups || 'useglobal' == $include_groups) { // set order depending on option setting
+        if ('' == $groups || 'useglobal' == $groups) { // set order depending on option setting
             $exclude_groups = get_option('events_nogroups', '1') == 1 ? true : false;
-        } elseif ('exclude' == $include_groups) {
+        } elseif ('n' == $groups) {
+            // the setting was 'n' - so exclude group events
             $exclude_groups = true;
         } else {
+            // the setting was 'y' - so include group events
             $exclude_groups = false;
         }
 

--- a/js/u3a-event-blocks.js
+++ b/js/u3a-event-blocks.js
@@ -218,11 +218,11 @@ wp.blocks.registerBlockType("u3a/eventdata", {
                   },
                   {
                     label: 'Exclude group events',
-                    value: 'exclude',
+                    value: 'n',
                   },
                   {
                     label: 'Include group events',
-                    value: 'include',
+                    value: 'y',
                   }
                   ]
                 }


### PR DESCRIPTION
Alter values returned for non-default settings on event lists back to their previous state, and test backwards compatibility.

Testing:
Created three event lists with old site. 
First list didnt touch the default setting. 
Second list set to 'y' - include group events.
Third set to 'y', then set to 'n', so removing the default value and inserting 'n' - exclude group events.

Checked with default global setting (unchecked):
Expected INCLUDE,INCLUDE,EXCLUDE - correct.

Checked with the global setting checked:
Expected EXCLUDE,INCLUDE,EXCLUDE - correct.

On new site, set up similar page but with four lists:
First list untouched setting - using default value
Second list set to "Include"
Third list set to "exclude"
Fourth list set to "Use Global Setting".

With global setting unchecked:
Expected INCLUDE,INCLUDE,EXCLUDE,INCLUDE - correct.

With global setting checked:
Expected EXCLUDE,INCLUDE,EXCLUDE,EXCLUDE - correct.

Imported page from old site to new site. Verified that the behaviour is unchanged for all lists.
