### PR TITLE
js attributes have defaults, same defaults in PHP

### DIFF
--- a/classes/class-u3a-event.php
+++ b/classes/class-u3a-event.php
@@ -623,7 +623,9 @@ class U3aEvent
      *    when = 'past'/'future' (default future)
      *    order = 'asc'/'desc' (defaults to asc for future and desc for past)
      *    event_cat = which event category to display (default all)
-     *    groups = corresponds to 'show group events and is 'useglobal' or 'y' or 'n'
+     *    groups = corresponds to 'show group events' and is 'useglobal' or 'y' or 'n'
+     *             '' is equivalent to 'useglobal' and is
+     *             kept for compatibility with blocks created in versions 1.2.2 or below
      *    limitnum (int) = limits how many events to be displayed
      *    limitdays (int) = limits how many day in the future or past to show events
      *    layout = 'list' or 'grid' at present. Other layouts may be added
@@ -640,7 +642,7 @@ class U3aEvent
             'when' => 'future',
             'order' => '',
             'event_cat' => 'all',
-            'groups' => '',
+            'groups' => 'useglobal',
             'limitdays' => 0,
             'limitnum' => 0,
             'layout' => 'list',
@@ -686,7 +688,7 @@ class U3aEvent
             &&  'n' != $groups && '' != $groups
         ) {
             $error .= 'bad parameter: groups=' . esc_html($groups) . '<br>';
-            $groups = '';
+            $groups = 'useglobal';
         }
         if ('' == $groups || 'useglobal' == $groups) { // set order depending on option setting
             $exclude_groups = get_option('events_nogroups', '1') == 1 ? true : false;

--- a/js/u3a-event-blocks.js
+++ b/js/u3a-event-blocks.js
@@ -17,31 +17,42 @@ wp.blocks.registerBlockType("u3a/eventdata", {
     description: "Displays list of events",
     icon: "tickets-alt",
     category: "widgets",
+    /* The default values of these attributes are used in the edit function below.
+       They are NOT stored in the HTML of the block unless setAttributes is used to set them.
+       The same default values are set in the PHP code of the callback for the block.
+    */
     attributes: {
       showtitle: {
         type: "string",
         default: "y"
       },
       when: {
-        type: "string"
+        type: "string",
+        default: "future"
       },
       order: {
-        type: "string"
+        type: "string",
+        default: ""
       },
       event_cat: {
-        type: "string"
+        type: "string",
+        default: "all"
       },
       groups: {
-        type: "string"
+        type: "string",
+        default: "useglobal"
       },
       limitnum: {
-        type: "integer"
+        type: "integer",
+        default: 0
       },
       limitdays: {
-        type: "integer"
+        type: "integer",
+        default: 0
       },
       layout: {
-          type: "string"
+        type: "string",
+        default: "list"
       },
       crop: {
         type: "string",


### PR DESCRIPTION
This corrects default values in the JS script, and also defaults in the PHP to 'useglobal' replacing ''. 

As the defaults in JS are never transmitted, this change will have no possible visible behaviour change for either new lists or old lists created on older versions.

The change of default in PHP is safe as the code path is identical for '' and 'useglobal'.

Just as a check I have re-run the tests and found no issues. 